### PR TITLE
add top level lib file so gem can be loaded

### DIFF
--- a/lib/unifi-api.rb
+++ b/lib/unifi-api.rb
@@ -1,0 +1,1 @@
+require 'unifi/api'


### PR DESCRIPTION
Fixes #1. This allows the gem to be loaded in other projects.

```
irb(main):001:0> require 'unifi-api'
=> true
```
