### PR TITLE
Add get_user and get_guests endpoints

### DIFF
--- a/lib/unifi/api.rb
+++ b/lib/unifi/api.rb
@@ -73,6 +73,15 @@ module Unifi
         read "#{api_url}list/user"
       end
 
+      def get_user(user_mac)
+        read "#{api_url}stat/user/#{user_mac}"
+      end
+
+      def get_guests(within=24)
+        params = {'within': within}
+        read "#{api_url}stat/guest", params
+      end
+
       def get_user_groups
         read "#{api_url}list/usergroup"
       end


### PR DESCRIPTION
Adds a couple of endpoints that I need for a project I'm working on.  Tested on Unifi controller version 5.14.23.  I don't have older versions handy to test with (note: you have to choose `v4` when initializing the client for v5 of the controller using this gem)